### PR TITLE
Allow gacha pulls of one or five

### DIFF
--- a/backend/src/RubberDev.Application/Services/GachaService.cs
+++ b/backend/src/RubberDev.Application/Services/GachaService.cs
@@ -20,9 +20,9 @@ public class GachaService : IGachaService
         int count,
         CancellationToken cancellationToken = default)
     {
-        if (count != 1 && count != 3)
+        if (count != 1 && count != 5)
             throw new ArgumentException(
-                "Pull count must be 1 or 3.", nameof(count));
+                "Pull count must be 1 or 5.", nameof(count));
 
         // 1) load all characters
         var allCharacters = (await _storageBroker

--- a/backend/src/RubberDev.Application/UseCases/IGachaService.cs
+++ b/backend/src/RubberDev.Application/UseCases/IGachaService.cs
@@ -8,7 +8,7 @@ namespace RubberDev.Application.UseCases;
 public interface IGachaService
 {
     /// <summary>
-    /// Perform a gacha pull of the specified count (1 or 3).
+    /// Perform a gacha pull of the specified count (1 or 5).
     /// </summary>
     Task<PullBatchDto> PullAsync(
         int count,


### PR DESCRIPTION
## Summary
- restrict pull counts to 1 or 5 in `GachaService`
- update interface comment

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684152fbb7b083239cc271f97a450532